### PR TITLE
Add libxkbcommon

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update -qq && \
         zip \
         unzip \
 	make \
-	libxkbcommon-x11
+	libxkbcommon-x11-0
 
 RUN curl -sL https://deb.nodesource.com/setup_14.x | sudo -E bash - \
     && sudo apt-get install -qq nodejs

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,8 @@ RUN apt-get update -qq && \
         jq \
         zip \
         unzip \
-	    make
+	make \
+	libxkbcommon-x11
 
 RUN curl -sL https://deb.nodesource.com/setup_14.x | sudo -E bash - \
     && sudo apt-get install -qq nodejs
@@ -23,6 +24,9 @@ RUN apt-get update -qq && \
     apt-get clean -qq && \
 	rm -rf /var/cache/oracle-jdk8-installer && \
     rm -rf /var/lib/apt/lists/*
+    
+
+    
 
 ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/
 RUN export JAVA_HOME


### PR DESCRIPTION
Puppetteer used by browserforce requires libxkbcommon. This is causing scritps which use pupetter to break